### PR TITLE
ci: skip draft lint Actions

### DIFF
--- a/.github/workflows/trunk_check.yml
+++ b/.github/workflows/trunk_check.yml
@@ -24,11 +24,12 @@ permissions: read-all
 
 jobs:
   trunk_check:
+    if: ${{ github.event.pull_request.draft == false }}
     name: Trunk Check Runner
     runs-on: ubuntu-latest
     permissions:
-      checks: write # For trunk to post annotations
-      contents: read # For repo checkout
+      checks: write
+      contents: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Reduce public runner usage without changing the action-under-test behavior.

- skip the ordinary Trunk lint runner while a pull request is draft
- preserve the action test workflow that intentionally observes draft/review transitions
- preserve existing concurrency and Trunk behavior